### PR TITLE
Makefile: remove redundant install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,9 +116,7 @@ ifeq ($(NESTED_MAKE),)
 	export $(GOENV) && gometalinter --install
 	@echo "$(A2) get glide"
 	go get -u github.com/Masterminds/glide
-	go install github.com/Masterminds/glide
 	go get -u github.com/josephspurrier/goversioninfo
-	go install github.com/josephspurrier/goversioninfo/cmd/goversioninfo
 	go install ./cmd/updatewinversioninfo/
 endif
 	@echo "$(S0)"


### PR DESCRIPTION
* Problem:
  * "go install" is not necessary after a "go get"
  * "go help get" specifically states that "Get downloads the packages named by the import paths, along with their dependencies. It then installs the named packages, like 'go install'"
* Implementation:
  * Removed any redundant "go install" entries
* Testing:
  * Verified that "go get" compiles and installs the package locally
* Bug: N/A