### PR TITLE
Makefile: restore "go install"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ ifeq ($(NESTED_MAKE),)
 	export $(GOENV) && gometalinter --install
 	@echo "$(A2) get glide"
 	go get -u github.com/Masterminds/glide
-	go get -u github.com/josephspurrier/goversioninfo
+	go get -u github.com/josephspurrier/goversioninfo/cmd/goversioninfo
 	go install ./cmd/updatewinversioninfo/
 endif
 	@echo "$(S0)"


### PR DESCRIPTION
* Problem:
  * goversioninfo binary isn't getting installed by the Makefile
* Implementation:
  * Need to update "go get" for goversioninfo package
* Testing:
  * Validated the correct "go get" also installs goversioninfo binary onto host
* Reviewers:
  * @shivamerla, @suneeth51, @rgcostea 
* Bug: N/A