### PR TITLE
dockervolumed: update iscsi params for managed plugin

### DIFF
--- a/cmd/dockervolumed/dockervolumed.go
+++ b/cmd/dockervolumed/dockervolumed.go
@@ -218,15 +218,20 @@ func handleConformance() (err error) {
 	// package conformance checks and automatic package installation is not supported for managed plugins
 	// so, only copy multipath.conf if missing
 	if plugin.IsManagedPlugin() {
-		if exists, _, _ := util.FileExists(linux.MultipathConf); exists {
-			return nil
+		// multipath checks
+		if exists, _, _ := util.FileExists(linux.MultipathConf); !exists {
+			// Copy the multipath.conf supplied with utility
+			multipathTemplate, err := tunelinux.GetMultipathTemplateFile()
+			if err != nil {
+				return err
+			}
+			err = util.CopyFile(multipathTemplate, linux.MultipathConf)
+			if err != nil {
+				return err
+			}
 		}
-		// Copy the multipath.conf supplied with utility
-		multipathTemplate, err := tunelinux.GetMultipathTemplateFile()
-		if err != nil {
-			return err
-		}
-		err = util.CopyFile(multipathTemplate, linux.MultipathConf)
+		// iscsi checks
+		err = tunelinux.SetIscsiRecommendations()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
* Problem:
  * For managed plugin we were only applying multipath template and not
  * iSCSI checks as systemctl was not available for managed plugin.
* Implementation:
  * nr_sessions=4 is required for CV managed plugin. So, just apply iscsid.conf
  * settings without any service checks for managed plugin
* Testing: tested on CentOs and AmazonLinux instances and ensured that nr_sessions=4 is applied.
* Review: gcostea, rkumar
* Bug: https://nimblejira.nimblestorage.com/browse/NLT-
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>