### PR TITLE
common-host-utils: fix version for avakel/rsrc package

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -6,3 +6,5 @@ import:
   version: v0.0.3
 - package: github.com/josephspurrier/goversioninfo
   version: 63e6d1acd3dd857ec6b8c54fbf52e10ce24a8786
+- package: github.com/akavel/rsrc
+  version: v0.8.0


### PR DESCRIPTION
* Problem:
  * There is a regression in latest version of avakel/rsrc package
  * which is causing compilation to fail.
* Implementation:
  * Fix this to last known stable version 0.8.0
* Testing: build succeded
* Review: gcostea, rkumar
* Bug:
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>